### PR TITLE
don't send out "prefer-encrypt=nopreference" in Autocrypt headers but…

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,8 +102,7 @@ Autocrypt.prototype.addUser = function (fromEmail, publicKey, opts, cb) {
   if (!cb && (typeof opts === 'function')) return self.addUser(fromEmail, publicKey, null, opts)
   if (!publicKey || (typeof publicKey !== 'string')) return cb(new Error('publicKey required.'))
   var defaults = {
-    public_key: publicKey,
-    'prefer-encrypt': 'nopreference'
+    public_key: publicKey
   }
   self.storage.put(fromEmail, xtend(defaults, opts), cb)
 }
@@ -133,12 +132,15 @@ Autocrypt.prototype.generateAutocryptHeader = function (fromEmail, cb) {
   var self = this
   self.storage.get(fromEmail, function (err, from) {
     if (err) return cb(err)
-    cb(null, Autocrypt.stringify({
+    var opts = {
       addr: fromEmail,
       type: '1',
-      keydata: from.public_key,
-      'prefer-encrypt': from['prefer-encrypt']
-    }))
+      keydata: from.public_key
+    }
+    if (from['prefer-encrypt'] === 'mutual') {
+      opts['prefer-encrypt'] = 'mutual'
+    }
+    cb(null, Autocrypt.stringify(opts))
   })
 }
 

--- a/test/generateHeader.js
+++ b/test/generateHeader.js
@@ -68,7 +68,7 @@ setup(bob, (bobCrypt, bobKey, doneBob) => {
           t.same(vals.keydata, aliceKey, 'alices public key is in the header')
           t.same(vals.addr, alice, 'email is for alice')
           t.same(vals.type, '1', 'type is 1')
-          t.same(vals['prefer-encrypt'], 'nopreference')
+          t.same(vals['prefer-encrypt'], undefined)
           aliceCrypt.recommendation(alice, bob, function (err, recommendation) {
             t.ifError(err)
             t.same(recommendation, 'available')
@@ -95,7 +95,7 @@ setup(bob, (bobCrypt, bobKey, doneBob) => {
           t.same(vals.keydata, aliceKey, 'bobs public key is in the header')
           t.same(vals.addr, alice, 'email is for alice')
           t.same(vals.type, '1', 'type is 1')
-          t.same(vals['prefer-encrypt'], 'nopreference')
+          t.same(vals['prefer-encrypt'], undefined)
           aliceCrypt.recommendation(alice, bob, function (err, recommendation) {
             t.ifError(err)
             t.same(recommendation, 'available')

--- a/test/users.js
+++ b/test/users.js
@@ -28,7 +28,7 @@ test('users: add and get a user with a public key has defaults', function (t) {
       crypt.getUser(email, (err, user) => {
         t.ifError(err)
         t.same(user.public_key, key, 'has public_key')
-        t.same(user['prefer-encrypt'], 'nopreference', 'nopreference is default')
+        t.same(user['prefer-encrypt'], undefined, 'nopreference is default')
         done(() => t.end())
       })
     })


### PR DESCRIPTION
… send out no prefer-encrypt setting at all (which then implicitely causes a default of "nopreference" on the receiving/parsing side)